### PR TITLE
Remove .env from git tracking

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment


### PR DESCRIPTION
I forgot to run `git rm --cached .env`. This will make sure it is not getting tracked in git anymore