### PR TITLE
fix typescript version to work with eslint version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-config-next": "14.2.5",
         "postcss": "^8.4.40",
         "tailwindcss": "^3.4.7",
-        "typescript": "^5.5.4"
+        "typescript": "^5.4.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "eslint-config-next": "14.2.5",
     "postcss": "^8.4.40",
     "tailwindcss": "^3.4.7",
-    "typescript": "^5.5.4"
+    "typescript": "^5.4.3"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,14 +69,14 @@ export default function Home() {
         <tbody>
           {filteredAdvocates.map((advocate) => {
             return (
-              <tr>
+              <tr key={advocate.id}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
                   {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                    <div key={s}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>


### PR DESCRIPTION
When running `npm run lint`, I saw this error:

```
WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=4.7.4 <5.5.0

YOUR TYPESCRIPT VERSION: 5.7.2
```

I downgraded the typescript package to work with eslint/typescript-estree. I also fixed the linting issues associated with the command.

After:
<img width="597" alt="image" src="https://github.com/user-attachments/assets/5a9fab2d-0af6-4fd0-a439-81df8eb168b7" />
